### PR TITLE
Increase version number

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: latex2exp
 Type: Package
 Title: Use LaTeX Expressions in Plots
-Version: 0.4.0
+Version: 0.4.1
 Date: 2015-11-30
 Authors@R: person("Stefano", "Meschiari", email="stefano.meschiari@gmail.com", role=c("aut", "cre"))
 Description: Parses and converts LaTeX math formulas to R's plotmath


### PR DESCRIPTION
GitHub version of **latex2exp** is superior to CRAN version, but both have the same version number. This is confusing in some situations.