### PR TITLE
0.9.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ experiment
 /doc/
 /Meta/
 docs
+CRAN-SUBMISSION

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,3 @@
 Version: 0.9.0
-Date: 2022-01-24 01:16:48 UTC
-SHA: 00c71d6858bd4e822918dc888efb3bd2e089d737
+Date: 2022-01-24 16:55:35 UTC
+SHA: 2ffdc0a8ad3105f5dbd3a247c00e7eabaf1ff9a6

--- a/R/symbols.R
+++ b/R/symbols.R
@@ -74,14 +74,13 @@ latex_supported = list(
   ),
 
   "binary operators" = list(
-    # need a phantom() here so that you could do multiple equalities.
-    # expression(a = b = c) results in a parse error.
     "=" = "$LEFT * {phantom() == phantom()} * $RIGHT",
     ">" = "$LEFT * {phantom() > phantom()} * $RIGHT",
     "<" = "$LEFT * {phantom() < phantom()} * $RIGHT",
-    "\\neq" = "$LEFT != $RIGHT",
-    "\\geq" = "$LEFT >= $RIGHT",
-    "\\leq" = "$LEFT <= $RIGHT",
+    "\\ne" = "$LEFT * {phantom() != phantom()} * $RIGHT",
+    "\\neq" = "$LEFT * {phantom() != phantom()} * $RIGHT",
+    "\\geq" = "$LEFT * {phantom() >= phantom()} * $RIGHT",
+    "\\leq" = "$LEFT * {phantom() <= phantom()} * $RIGHT",
     
     "\\div" = "$LEFT %/% $RIGHT",
     "\\pm" = "$LEFT %+-% $RIGHT",
@@ -241,6 +240,7 @@ latex_supported = list(
   ),
 
   # Characters that need to be treated in a special way by the parser
+  # when in math mode
   "specials" = list(
     "," = "list(,)",
     "|" = "group('|', phantom(), '')"

--- a/tests/testthat/test_simple.R
+++ b/tests/testthat/test_simple.R
@@ -34,6 +34,8 @@ test_that("Operators are rendered correctly, regardless of spacing", {
                       a * {phantom() == phantom()} * b * {phantom() == phantom()} * c)
   expect_renders_same("$a > b < c$",
                       a * {phantom() > phantom()} * b * {phantom() < phantom()} * c)
+  expect_renders_same("$a \\ne b \\leq c \\geq d$",
+                      {a != b} <= {c >= d})
   
 })
 test_that("Special characters in math or text mode do not cause errors", {
@@ -45,6 +47,13 @@ test_that("Special characters in math or text mode do not cause errors", {
                       a * second)
   expect_renders_same("R's plotmath system",
                       'R\'s plotmath system')
+  
+  # commas should render differently depending on whether they 
+  # are inside math mode or not.
+  expect_renders_same("a, b, c",
+                      "a, b, c")
+  expect_renders_same("$a,b,c$",
+                      list(a, b, c))
 })
 
 test_that("Grouping over deeply nested commands renders correctly", {


### PR DESCRIPTION
Fixes #38 

Commands `\leq`, `\geq`, and `\ne` (synonym: `\neq`) are protected by surrounding them with `{phantom() * operator * phantom() }` to avoid errors when translating into a plotmath expression.

This is necessary because a plotmath expression like `a < b < c` is not a valid R expression, and will cause a parse error:
```
Error: unexpected '<' in "a < b <"
```
The workaround applied currently is to surround the operator in `{phantom() * operator * phantom()}`.

In a follow-up release, I should devise a better solution.