### PR TITLE
Ensure that calling TeX with an empty argument returns expression('')

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# 0.9.1 [02/01/2022]
+* Fix handling of compare operators (`=, <, >, \ge, \le`) (fixes issue #38)
+* `TeX("")` returns `expression('')` (an empty expression of length 1) (fixes issue #40)
+
 # 0.9.0 [01/20/2022]
 
 * Completely rewritten parser that is much more robust, produces valid plotmath
@@ -15,7 +19,7 @@
   * `\bra`, `\ket`, `\braket` for representing vectors with the braket notation
   * `\smiley`, `\diamond`, `\sharp`, `\eightnote`, `\twonotes`, `\sun`, `\venus`,
     `\mars`, `\Exclam`, `\dagger`, `\ddagger`, `\(up|down|right|left)triangle`
-* Improved the appearance of round parentheses. `TeX(r"($\alpha(\beta)$)")` now renders more similarly to how plotmath renders the expression `alpha(beta)`. 
+* Improved the appearance of round parentheses. `TeX(r"($\alpha(\beta)$)")` now renders more similarly to how plotmath renders the expression `alpha(beta)`.
 * Improved the appearance of `,`, `'` and `''` in math mode.
 * Improved the appearance of `\frac` fractions. Now a small space is inserted after the fraction, so that multiple fractions are separated.
 * Added a test suite covering a large number of LaTeX expressions, edge cases, and examples from GitHub.

--- a/R/latex2exp.R
+++ b/R/latex2exp.R
@@ -111,17 +111,21 @@ TeX <-
       return(rendered)
     }
     
-    
-    expression <- tryCatch(str2expression(rendered), error=function(e) {
+    rendered_expression <- tryCatch(str2expression(rendered), error=function(e) {
       stop("Error while converting LaTeX into plotmath.\n",
            "Original string: ", input, "\n",
            "Parsed expression: ", rendered, "\n",
            e)
-    })  
+    })
     
-    class(expression) <- c("latexexpression", "expression")
-    attr(expression, "latex") <- input
-    attr(expression, "plotmath") <- rendered
+    # if the rendered expression is empty, return expression('') instead.
+    if (length(rendered_expression) == 0) {
+      rendered_expression <- expression('')
+    }
     
-    expression
+    class(rendered_expression) <- c("latexexpression", "expression")
+    attr(rendered_expression, "latex") <- input
+    attr(rendered_expression, "plotmath") <- rendered
+    
+    rendered_expression
   }

--- a/tests/testthat/test_simple.R
+++ b/tests/testthat/test_simple.R
@@ -158,3 +158,17 @@ test_that("Certain invalid LaTeX fails", {
   expect_error({ TeX("$\\bar{A$") })
   expect_error({ TeX("$\\left{\\left{A\\right}$") })
 })
+
+test_that("Type and length of return value is as expected", {
+  expect_length(TeX("$a$"), 1)
+  expect_length(TeX(c("$a$", "$b$")), 2)
+  expect_length(TeX(""), 1)
+  
+  expect_s3_class(TeX("$a$"), "expression")
+  expect_s3_class(TeX("$a$"), "latexexpression")
+  
+  expect_s3_class(TeX(""), "expression")
+  expect_s3_class(TeX(""), "latexexpression")
+  
+  expect_type(TeX("$a$", output="character"), "character")
+})


### PR DESCRIPTION
Fixes #40 by returning `expression('')` when `TeX` is called with an empty string.

Adds tests around expected return type/class and length.