### PR TITLE
0.9.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: latex2exp
 Type: Package
 Title: Use LaTeX Expressions in Plots
-Version: 0.9.2
-Date: 2022-02-01
+Version: 0.9.3
+Date: 2022-02-02
 Authors@R: person("Stefano", "Meschiari", email="stefano.meschiari@gmail.com", role=c("aut", "cre"))
 Description: Parses and converts LaTeX math formulas to R's plotmath
     expressions, used to enter mathematical formulas and symbols to be rendered as
@@ -10,11 +10,11 @@ Description: Parses and converts LaTeX math formulas to R's plotmath
 License: MIT + file LICENSE
 URL: https://www.stefanom.io/latex2exp/, https://github.com/stefano-meschiari/latex2exp
 BugReports: https://github.com/stefano-meschiari/latex2exp/issues
-Imports: 
+Imports:
     stringr,
     magrittr
 Encoding: UTF-8
-Suggests: 
+Suggests:
     testthat,
     knitr,
     ggplot2,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
-# 0.9.2 [02/01/2022]
+# 0.9.3 [02/02/2022]
+* Fix an edge case encountered with back-to-back spacing or certain types of commands (e.g. `TeX(r"(a \,\, b)"`)) (fixes issue #40)
 * Fix handling of compare operators (`=, <, >, \ge, \le`) (fixes issue #38)
 * `TeX("")` returns `expression('')` (an empty expression of length 1) (fixes issue #40)
 

--- a/R/parser.R
+++ b/R/parser.R
@@ -13,6 +13,21 @@
   tok
 }
 
+clone_token <- function(tok) {
+  if (is.list(tok)) {
+    return(lapply(tok, clone_token))
+  }
+  new_tok <- .token2(tok$command, tok$text_mode)
+  # clone all the linked tokens
+  for (field in c("children", "args", "optional_arg", "sup_arg", "sub_arg")) {
+    new_tok[[field]] <- lapply(tok[[field]], clone_token)
+  }
+  for (field in c("is_command", "left_operator", "right_operator")) {
+    new_tok[[field]] <- tok[[field]]
+  }
+  new_tok
+}
+
 .find_substring <- function(string, boundary_characters) {
   pattern <- str_c("^[^",
                    str_c("\\", boundary_characters, collapse=""),
@@ -296,9 +311,25 @@ parse_latex <- function(latex_string,
   }
 }
 
-render_latex <- function(tokens, user_defined=list()) {
+#' Renders a LaTeX tree
+#' 
+#' Returns a string that is a valid plotmath expression, given a LaTeX tree
+#' returned by \code{\link{parse_latex}}.
+#'
+#' @param tokens tree of tokens
+#' @param user_defined any custom definitions of commands passed to \code{\link{TeX}}
+#' @param hack_parentheses render parentheses using \code{group('(', phantom(), '.')} and
+#'                         \code{group(')', phantom(), '.')}. This is useful to return
+#'                         valid expressions when the LaTeX source contains mismatched
+#'                         parentheses, but makes the returned expression much 
+#'                         less tidy.
+#' @return
+#' @export
+#'
+#' @examples
+render_latex <- function(tokens, user_defined=list(), hack_parentheses=FALSE) {
   if (!is.null(tokens$children)) {
-    return(render_latex(tokens$children, user_defined))
+    return(render_latex(tokens$children, user_defined, hack_parentheses=hack_parentheses))
   }
   translations <- c(user_defined, latex_supported_map)
   
@@ -371,7 +402,7 @@ render_latex <- function(tokens, user_defined=list()) {
                                         fixed("$LEFT"),
                                         "phantom()")
       } else if (tokens[[tok_idx-1]]$right_operator) {
-        # or the previous token was also an operator.
+        # or the previous token was also an operator or an open parentheses.
         # Bind the tokens using phantom()
         tok$rendered <- str_replace_all(tok$rendered,
                                         fixed("$LEFT"),
@@ -397,16 +428,16 @@ render_latex <- function(tokens, user_defined=list()) {
     }
     if (length(tok$args) > 0) {
       for (argidx in seq_along(tok$args)) {
-        args <- render_latex(tok$args[[argidx]], user_defined)
+        args <- render_latex(tok$args[[argidx]], user_defined, hack_parentheses=hack_parentheses)
         argfmt <- str_c("$arg", argidx)
         if (str_detect(tok$rendered, fixed(argfmt))) {
           tok$rendered <- str_replace_all(tok$rendered,
-                                            fixed(argfmt),
-                                            args)
+                                          fixed(argfmt),
+                                          args)
         } else {
           if (tok$rendered != "{}") {
             tok$rendered <- str_c(tok$rendered, " * {",
-                                    args, "}")
+                                  args, "}")
           } else {
             tok$rendered <- str_c("{", args, "}")    
           }
@@ -415,7 +446,7 @@ render_latex <- function(tokens, user_defined=list()) {
     } 
     
     if (length(tok$optional_arg) > 0) {
-      optarg <- render_latex(tok$optional_arg, user_defined)
+      optarg <- render_latex(tok$optional_arg, user_defined, hack_parentheses=hack_parentheses)
       tok$rendered <- str_replace_all(tok$rendered,
                                         fixed("$opt"),
                                         optarg)
@@ -426,7 +457,7 @@ render_latex <- function(tokens, user_defined=list()) {
       argfmt <- str_c("$", type)
       
       if (length(arg) > 0) {
-        rarg <- render_latex(arg, user_defined)
+        rarg <- render_latex(arg, user_defined, hack_parentheses=hack_parentheses)
         
         if (str_detect(tok$rendered, fixed(argfmt))) {
           tok$rendered <- str_replace_all(tok$rendered, fixed(argfmt), rarg)
@@ -462,12 +493,23 @@ render_latex <- function(tokens, user_defined=list()) {
       tok$right_separator <- " * phantom(.)"
     }
     
-    if (tok$command == "(" || tok$command == ")") {
-      tok$left_separator <- ""
-      tok$right_separator <- ""
-    } 
-    if (tok_idx > 1 && tokens[[tok_idx-1]]$command == "(") {
-      tok$left_separator <- ""
+    if (!hack_parentheses) {
+      if (tok$command %in% c("(", ")")) {
+        tok$left_separator <- ""
+        tok$right_separator <- ""
+      } 
+      if (tok_idx > 1 && tokens[[tok_idx-1]]$command == "(") {
+        tok$left_separator <- ""
+      }
+    } else {
+      if (tok$command %in% c("(", ")") && !tok$text_mode) {
+        cat_trace("Using hack for parentheses")
+        if (tok$command == "(") {
+          tok$rendered <- "group('(', phantom(), '.')"
+        } else if (tok$command == ")") {
+          tok$rendered <- "group(')', phantom(), '.')"
+        }
+      }
     }
     
     # If the token still starts with a "\", substitute it

--- a/tests/testthat/test_examples.r
+++ b/tests/testthat/test_examples.r
@@ -48,4 +48,6 @@ test_that("Samples from GitHub issues are rendered correctly", {
   expect_renders_same("$\\bar{A}^{a;a \\rightarrow i}_{x;n\\rceil}$",
                       bar(A)[group('.', x*';'*n, rceil)]^{a*';'*a %->% i})
   
+  expect_renders_same("$\\,\\,\\mu - 3 \\sigma$",
+                      phantom(.) * phantom(.) * mu - 3 * sigma)
 })

--- a/tests/testthat/test_examples.r
+++ b/tests/testthat/test_examples.r
@@ -47,7 +47,11 @@ test_that("Samples from GitHub issues are rendered correctly", {
   
   expect_renders_same("$\\bar{A}^{a;a \\rightarrow i}_{x;n\\rceil}$",
                       bar(A)[group('.', x*';'*n, rceil)]^{a*';'*a %->% i})
-  
+  # https://github.com/stefano-meschiari/latex2exp/issues/43
   expect_renders_same("$\\,\\,\\mu - 3 \\sigma$",
                       phantom(.) * phantom(.) * mu - 3 * sigma)
+  
+  expect_renders_same(sprintf("($\\mu$=%.0f) $E(\\bar{x}) \\, =$%.0f; $\\sigma_{\\bar{x}} \\, =$%.0f", 10, 12, 14),
+                      '(' * mu * '=10) ' * { E(bar(x)) * phantom(.) == 12 } * '; ' *  
+                        { sigma[bar(x)] * phantom(.) == 14 })
 })

--- a/tests/testthat/test_simple.R
+++ b/tests/testthat/test_simple.R
@@ -188,3 +188,12 @@ test_that("Consecutive operators can be parsed", {
   expect_renders_same("$a\\,\\,\\;\\; b$",
                       a*phantom(.) * phantom(.) * phantom() ~~ phantom() ~~ b)
 })
+
+test_that("Certain edge cases will attempt to render correctly", {
+  expect_renders_same("$\\bar{x} \\, (\\neq x)$",
+                      bar(x) * phantom(.) * (phantom() != x))
+  expect_renders_same("$)a($",
+                      group(')', a, '('))
+  expect_renders_same(")$a($",
+                      ')' * group('.', a, '('))
+})

--- a/tests/testthat/test_simple.R
+++ b/tests/testthat/test_simple.R
@@ -181,3 +181,10 @@ test_that("Type and length of return value is as expected", {
   
   expect_type(TeX("$a$", output="character"), "character")
 })
+
+test_that("Consecutive operators can be parsed", {
+  expect_renders_same("$a \\pm \\pm b$",
+                      a %+-% phantom() %+-% b)
+  expect_renders_same("$a\\,\\,\\;\\; b$",
+                      a*phantom(.) * phantom(.) * phantom() ~~ phantom() ~~ b)
+})


### PR DESCRIPTION
Fix an edge case encountered with back-to-back spacing or certain types of commands (e.g. `TeX(r"(a \,\, b)"`)) (fixes issue #43). This is done by detecting if the previous token was a symbol of type operator, and adding a `phantom()` to the left of the current command.